### PR TITLE
Add success message after build completion

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -100,3 +100,18 @@ compose.desktop {
         }
     }
 }
+
+val printSuccessMessage by tasks.registering {
+    doLast {
+        println("✅Build completed successfully!")
+    }
+}
+tasks.named("build") {
+    finalizedBy(printSuccessMessage)
+}
+
+
+
+
+
+


### PR DESCRIPTION
Introduced a new Gradle task to print a success message after the build finishes. The 'build' task is now finalized by this new task to improve developer feedback.