### PR TITLE
Integrate BuildKonfig for Supabase config management

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,14 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath(libs.kotlin.gradle.plugin)
+        classpath(libs.buildkonfig.gradle.plugin)
+    }
+}
 plugins {
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader

--- a/buildSrc/src/main/kotlin/References.kt
+++ b/buildSrc/src/main/kotlin/References.kt
@@ -1,5 +1,6 @@
 import org.gradle.api.JavaVersion
 import java.util.Calendar
+import java.util.Properties
 
 /**
  * The package name of the application.
@@ -58,6 +59,34 @@ val mVersionCode = "${getYear()}${getMonth()}${getDay()}"
  * this will be "1.0.0 (20231025)".
  */
 val appFullVersion = "$appVersion ($mVersionCode)"
+
+/**
+ * Enum class representing Supabase properties.
+ *
+ * This enum defines the keys for various Supabase configuration settings,
+ * such as the project URL and public authentication key. Each property
+ * is associated with a unique string key used for accessing its value.
+ *
+ * @property key The string key associated with the Supabase property.
+ */
+enum class SupabaseProperties(val key: String) {
+
+    /**
+     * The URL of your Supabase project.
+     *
+     * This is the unique endpoint for accessing your Supabase backend services,
+     * such as the database, authentication, and storage.
+     * It typically looks like `https://<your-project-id>.supabase.co`.
+     */
+    SUPABASE_URL("SUPABASE_URL"),
+
+    /**
+     * The public key for Supabase authentication.
+     * This key is used to identify the application when interacting with Supabase services.
+     */
+    SUPABASE_PUBLIC_KEY("SUPABASE_PUBLIC_KEY")
+
+}
 
 /**
  * Retrieves the current year.

--- a/composeApp/src/commonMain/kotlin/com/sotsap/apps/gymmanagement/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/sotsap/apps/gymmanagement/App.kt
@@ -22,6 +22,10 @@ import gymmanagement.composeapp.generated.resources.compose_multiplatform
 @Preview
 fun App() {
     MaterialTheme {
+        val supabaseKey = BuildKonfig.supabaseToken
+        val supabaseUrl = BuildKonfig.supabaseUrl
+        val appVersion = BuildKonfig.appVersion
+
         var showContent by remember { mutableStateOf(false) }
         Column(
             modifier = Modifier
@@ -29,8 +33,13 @@ fun App() {
                 .fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+
+            Text(text = supabaseKey)
+            Text(text = supabaseUrl)
+            Text(text = appVersion)
+
             Button(onClick = { showContent = !showContent }) {
-                Text("Click me!")
+                Text("")
             }
             AnimatedVisibility(showContent) {
                 val greeting = remember { Greeting().greet() }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,10 @@ junit = "4.13.2"
 kotlin = "2.2.0"
 kotlinx-coroutines = "1.10.2"
 
+buildKonfig = "0.17.1"
+kotlinGradlePlugin = "1.9.0"
+
+# ? ------------------------------------------------------------------------------------------------
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
@@ -32,6 +36,12 @@ androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:life
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 
+# BuildKonfig gradle plugin
+buildkonfig-gradle-plugin = { module = "com.codingfeline.buildkonfig:buildkonfig-gradle-plugin", version.ref = "buildKonfig" }
+# Kotlin gradle plugin
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin" }
+
+# ? ------------------------------------------------------------------------------------------------
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
@@ -39,3 +49,4 @@ composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "com
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+buildkonfig = { id = "com.codingfeline.buildkonfig" }


### PR DESCRIPTION
Added BuildKonfig plugin and configuration to expose Supabase URL, public key, and app version as build config fields. Updated build scripts to load secrets from local.properties or environment variables for CI/CD compatibility. Modified App.kt to display these config values at runtime. Extended References.kt with SupabaseProperties enum for key management. Updated dependencies and plugin versions in libs.versions.toml.